### PR TITLE
Add AOCODAF405V3_SD target

### DIFF
--- a/configs/AOCODAF405V3_SD/config.h
+++ b/configs/AOCODAF405V3_SD/config.h
@@ -1,0 +1,137 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define FC_TARGET_MCU     STM32F405
+
+#define BOARD_NAME        AOCODAF405V3
+#define MANUFACTURER_ID   SJET
+
+#define USE_GYRO
+#define USE_GYRO_SPI_MPU6000
+#define USE_GYRO_SPI_ICM42688P
+#define USE_ACC
+#define USE_ACC_SPI_MPU6000
+#define USE_ACC_SPI_ICM42688P
+#define USE_BARO
+#define USE_BARO_DPS310
+#define USE_BARO_BMP280
+#define USE_BARO_MS5611
+#define USE_MAG
+#define USE_MAG_HMC5883
+#define USE_MAG_QMC5883
+#define USE_SDCARD
+#define USE_MAX7456
+
+
+#define BEEPER_PIN         PB8
+#define MOTOR1_PIN         PC6
+#define MOTOR2_PIN         PC7
+#define MOTOR3_PIN         PC8
+#define MOTOR4_PIN         PC9
+#define MOTOR5_PIN         PA15
+#define MOTOR6_PIN         PA8
+#define MOTOR7_PIN         PB10
+#define MOTOR8_PIN         PB11
+#define RX_PPM_PIN         PA3
+#define LED_STRIP_PIN      PB1
+#define UART1_TX_PIN       PA9
+#define UART2_TX_PIN       PA2
+#define UART3_TX_PIN       PC10
+#define UART4_TX_PIN       PA0
+#define UART5_TX_PIN       PC12
+#define UART1_RX_PIN       PA10
+#define UART2_RX_PIN       PA3
+#define UART3_RX_PIN       PC11
+#define UART4_RX_PIN       PA1
+#define UART5_RX_PIN       PD2
+#define I2C1_SCL_PIN       PB6
+#define I2C1_SDA_PIN       PB7
+#define LED0_PIN           PC13
+#define SPI1_SCK_PIN       PA5
+#define SPI2_SCK_PIN       PB13
+#define SPI3_SCK_PIN       PB3
+#define SPI1_SDI_PIN       PA6
+#define SPI2_SDI_PIN       PB14
+#define SPI3_SDI_PIN       PB4
+#define SPI1_SDO_PIN       PA7
+#define SPI2_SDO_PIN       PB15
+#define SPI3_SDO_PIN       PB5
+#define ESCSERIAL_PIN      PC11
+#define ADC_VBAT_PIN       PC2
+#define ADC_RSSI_PIN       PC3
+#define ADC_CURR_PIN       PC1
+#define SDCARD_SPI_CS_PIN  PC0
+#define SDCARD_DETECT_PIN  PC14
+#define MAX7456_SPI_CS_PIN PA13
+#define GYRO_1_EXTI_PIN    PC4
+#define GYRO_1_CS_PIN      PA4
+#define USB_DETECT_PIN     PB12
+#define PINIO1_PIN         PC5
+#define PINIO2_PIN         PA14
+#define PINIO3_PIN         PC15
+
+#define TIMER_PIN_MAPPING \
+    TIMER_PIN_MAP( 0, PA3 , 2,  0) \
+    TIMER_PIN_MAP( 1, PC6 , 2,  1) \
+    TIMER_PIN_MAP( 2, PC7 , 2,  1) \
+    TIMER_PIN_MAP( 3, PC8 , 2,  1) \
+    TIMER_PIN_MAP( 4, PC9 , 2,  0) \
+    TIMER_PIN_MAP( 5, PA15, 1,  0) \
+    TIMER_PIN_MAP( 6, PA8 , 1,  1) \
+    TIMER_PIN_MAP( 7, PB10, 1,  0) \
+    TIMER_PIN_MAP( 8, PB11, 1,  0) \
+    TIMER_PIN_MAP( 9, PB1 , 2,  0)
+
+#define ADC_INSTANCE ADC3
+#define ADC3_DMA_OPT        1
+
+#define GPS_UART SERIAL_PORT_USART1
+#define SERIALRX_UART SERIAL_PORT_USART2
+#define MSP_UART SERIAL_PORT_UART5
+
+#define DEFAULT_FEATURES                (FEATURE_OSD | FEATURE_LED_STRIP | FEATURE_GPS )
+
+#define MAG_I2C_INSTANCE (I2CDEV_1)
+#define BARO_I2C_INSTANCE (I2CDEV_1)
+#define DEFAULT_BLACKBOX_DEVICE BLACKBOX_DEVICE_SDCARD
+#define DEFAULT_DSHOT_BURST DSHOT_DMAR_OFF
+#define DEFAULT_DSHOT_BITBANG DSHOT_BITBANG_OFF
+#define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
+#define DEFAULT_VOLTAGE_METER_SOURCE VOLTAGE_METER_ADC
+#define DEFAULT_CURRENT_METER_SCALE 500
+#define BEEPER_INVERTED
+#define SDCARD_DETECT_INVERTED
+#define USE_SDCARD_SPI
+#define SDCARD_SPI_INSTANCE SPI3
+#define SYSTEM_HSE_MHZ 8
+#define MAX7456_SPI_INSTANCE SPI2
+#define PINIO1_BOX 40
+#define PINIO2_BOX 41
+#define PINIO3_BOX 42
+#define PINIO1_CONFIG 129
+#define PINIO2_CONFIG 129
+#define PINIO3_CONFIG 1
+#define SERIALRX_PROVIDER SERIALRX_CRSF
+#define USE_SPI_GYRO
+#define GYRO_1_SPI_INSTANCE SPI1
+#define GYRO_1_ALIGN CW90_DEG


### PR DESCRIPTION
1.Serial port 1 Use GPS
2.Serial port 2 Use a receiver
3.The features of LED_STRIP、OSD、GPS are enabled by default 4.The default GPS protocol is ublox by default
5.The receiver selects CRSF protocol by default
6.The default motor protocol is Dshot600 by default 
7.Bluetooth and 9v switches are enabled by default
8. Use the User1 and User2 mode，User3 mode
9. Add User3 mode. User3 mode Controls the switchover between cam1 and cam2
10. Replace flash with SDcard